### PR TITLE
fix: missing project reference from test project to client project

### DIFF
--- a/template/AsyncapiNatsClientTests/AsyncapiNatsClientTests.csproj
+++ b/template/AsyncapiNatsClientTests/AsyncapiNatsClientTests.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\AsyncapiNatsClient\AsyncapiNatsClient.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
**Description**
Add the missing reference to the project file


**Related issue(s)**
Fixes: #177 