### PR TITLE
fix: add missing Microsoft.CSharp dependency

### DIFF
--- a/template/AsyncapiNatsClient/AsyncapiNatsClient.csproj.js
+++ b/template/AsyncapiNatsClient/AsyncapiNatsClient.csproj.js
@@ -32,6 +32,7 @@ export default function asyncapiNatsClient({ params }) {
   <ItemGroup>
     <PackageReference Include="NATS.Client" Version="0.12.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 </Project>`
     }


### PR DESCRIPTION
**Description**
This PR adds a missing C# dependency.

Otherwise, the following error will be thrown when compiling:

```
error CS0656: Missing compiler required member 'Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create'
```

Used the following answer on stack overflow: https://stackoverflow.com/questions/59361585/how-to-fix-error-cs0656-missing-compiler-required-member-microsoft-csharp-run#comment127346128_59396682