### PR TITLE
fix: refactor link to react render to point to the correct file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@ To contribute to this project, follow the rules from the general [CONTRIBUTING.m
 
 ## Getting started
 Extending the contribution guidelines above here is how to quick start your contribution process.
-* The template is rendered using the AsyncAPI generator React renderer, [the authoring docs](https://github.com/asyncapi/generator/blob/master/docs/authoring.md#react-1) is great way to quick start your template journey to understand the setup.
+* The template is rendered using the AsyncAPI generator React renderer, [the authoring docs](https://github.com/asyncapi/generator/blob/master/docs/react-render-engine.md) is great way to quick start your template journey to understand the setup.
 * Before requesting a review for your PR ensure that all CI checks succeeds, if you don't know why they fail feel free to tag one of the main contributors.
 * If you are stuck or just want to discuss things feel free to reach out on [slack](https://www.asyncapi.com/slack-invite).


### PR DESCRIPTION
**Description**
- Updated the react link to match the new structure of the generator docs re-structure after deleting **authoring.md**

**Related issue(s)**
See [793](https://github.com/asyncapi/generator/pull/793)